### PR TITLE
chore: remove gno build usage 

### DIFF
--- a/internal/gno/gno_test.go
+++ b/internal/gno/gno_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestNewManager(t *testing.T) {
-	mgr, _ := gno.NewBinManager("", "", false, false)
+	mgr, _ := gno.NewBinManager("", "", "", false, false)
 	if mgr != nil {
 		t.Logf("gno bin: %s", mgr.GnoBin())
 	} else {

--- a/internal/handler/code_lens.go
+++ b/internal/handler/code_lens.go
@@ -80,7 +80,7 @@ func addTestCmds(gnoBin, path string, tAndB testFns) []protocol.CodeLens {
 	cmds = append(cmds, newHeaderCmd(
 		"run package tests",
 		"gnols.test",
-		[]interface{}{gnoBin, path, ""},
+		[]interface{}{path, "*"},
 	))
 
 	inFile := []string{}
@@ -91,7 +91,7 @@ func addTestCmds(gnoBin, path string, tAndB testFns) []protocol.CodeLens {
 			Command: &protocol.Command{
 				Title:     "run test",
 				Command:   "gnols.test",
-				Arguments: []interface{}{gnoBin, path, fn.Name},
+				Arguments: []interface{}{path, fn.Name},
 			},
 		})
 	}
@@ -99,7 +99,7 @@ func addTestCmds(gnoBin, path string, tAndB testFns) []protocol.CodeLens {
 	cmds = append(cmds, newHeaderCmd(
 		"run file tests",
 		"gnols.test",
-		[]interface{}{gnoBin, path, strings.Join(inFile, "|")},
+		[]interface{}{path, strings.Join(inFile, "|")},
 	))
 
 	return cmds
@@ -114,7 +114,7 @@ func addBenchCmds(gnoBin, path string, tAndB testFns) []protocol.CodeLens {
 	cmds = append(cmds, newHeaderCmd(
 		"run package benchmarks",
 		"gnols.bench",
-		[]interface{}{gnoBin, path, ""},
+		[]interface{}{path, ""},
 	))
 
 	inFile := []string{}
@@ -125,7 +125,7 @@ func addBenchCmds(gnoBin, path string, tAndB testFns) []protocol.CodeLens {
 			Command: &protocol.Command{
 				Title:     "run benchmark",
 				Command:   "gnols.bench",
-				Arguments: []interface{}{gnoBin, path, fn.Name},
+				Arguments: []interface{}{path, fn.Name},
 			},
 		})
 	}
@@ -133,7 +133,7 @@ func addBenchCmds(gnoBin, path string, tAndB testFns) []protocol.CodeLens {
 	cmds = append(cmds, newHeaderCmd(
 		"run file benchmarks",
 		"gnols.bench",
-		[]interface{}{gnoBin, path, strings.Join(inFile, "|")},
+		[]interface{}{path, strings.Join(inFile, "|")},
 	))
 
 	return cmds

--- a/internal/handler/command.go
+++ b/internal/handler/command.go
@@ -18,7 +18,7 @@ func (h *handler) handleExecuteCommand(ctx context.Context, reply jsonrpc2.Repli
 	} else if err := json.Unmarshal(req.Params(), &params); err != nil {
 		return badJSON(ctx, reply, err)
 	}
-	slog.Info("execute_command", "command", params.Command)
+	slog.Info("execute_command", "command", params.Command, "args", params.Arguments)
 
 	switch params.Command { //nolint:gocritic
 	case "gnols.test":

--- a/internal/handler/config.go
+++ b/internal/handler/config.go
@@ -30,7 +30,8 @@ func (h *handler) handleDidChangeConfiguration(ctx context.Context, reply jsonrp
 
 	precompile, _ := settings["precompileOnSave"].(bool)
 	build, _ := settings["buildOnSave"].(bool)
+	root, _ := settings["root"].(string)
 
-	h.binManager, err = gno.NewBinManager(gnoBin, gnokey, precompile, build)
+	h.binManager, err = gno.NewBinManager(gnoBin, gnokey, root, precompile, build)
 	return reply(ctx, nil, err)
 }


### PR DESCRIPTION
/!\ Merge only after #3 

`gno build` has been removed in favor of `gno precompile -gobuild`. This PR updates gnols accordingly.

The only commit that should be reviewed with this PR is 495f58967e4ca05b2de9547d86f4b2ae7298c010.

This PR is based on PR #3 but I cannot target the branch since it comes from my fork. 
